### PR TITLE
Feature: save areas to api

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@mapbox/geojson-area": "^0.2.2",
     "classnames": "^2.2.5",
     "fecha": "^2.3.1",
     "file-saver": "^1.3.3",

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -20,6 +20,7 @@ class App extends React.Component {
 
   componentWillMount() {
     this.props.checkLogged(this.props.location.search);
+    this.props.getGeoStoresWithAreas();
   }
 
   getRootComponent = () => {
@@ -69,7 +70,8 @@ App.propTypes = {
   userChecked: PropTypes.bool.isRequired,
   user: PropTypes.object.isRequired,
   checkLogged: PropTypes.func.isRequired,
-  logout: PropTypes.func.isRequired
+  logout: PropTypes.func.isRequired,
+  getGeoStoresWithAreas: PropTypes.func.isRequired
 };
 
 export default App;

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -56,7 +56,7 @@ class App extends React.Component {
             </div>
           }
           {!user.loggedIn && <Redirect to="/" />}
-          <ReduxToastr />
+          <ReduxToastr position="bottom-right" />
         </main>
       </div>
     );

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -8,7 +8,7 @@ import ReduxToastr from 'react-redux-toastr'
 import Login from '../pages/login/Login';
 import Dashboard from '../pages/dashboard/DashboardContainer';
 import Areas from '../pages/areas/AreasContainer';
-import AreasManage from '../pages/areas-manage/AreasManage';
+import AreasManage from '../pages/areas-manage/AreasManageContainer';
 import Reports from '../pages/reports/ReportsContainer';
 import Answers from '../pages/answers/AnswersContainer';
 import AnswersDetail from '../pages/answers-detail/AnswersDetailContainer';

--- a/src/components/app/AppContainer.js
+++ b/src/components/app/AppContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom'
 import { checkLogged, logout } from '../../modules/user';
+import { getGeoStoresWithAreas } from '../../modules/areas';
 import App from './App';
 
 const mapStateToProps = ({ app, user }) => ({
@@ -15,6 +16,9 @@ function mapDispatchToProps(dispatch) {
     },
     logout: () => {
       dispatch(logout());
+    },
+    getGeoStoresWithAreas: () => {
+      dispatch(getGeoStoresWithAreas());
     }
   };
 }

--- a/src/components/area-card/AreaCardContainer.js
+++ b/src/components/area-card/AreaCardContainer.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import AreaCard from './AreaCard';
 
 const mapStateToProps = ({ areas }, { id }) => {
-  const area = areas.area[id] && areas.area[id].attributes;
+  const area = areas.areas[id] && areas.areas[id].attributes;
   return { area: { ...area, id } };
 };
 

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
-import { Draw, Control } from 'leaflet-draw'; // eslint-disable-line no-unused-vars
-import { leafletSearch } from 'leaflet-search'; // eslint-disable-line no-unused-vars
 import 'leaflet/dist/leaflet.css';
-import 'leaflet-draw/dist/leaflet.draw.css';
-import 'leaflet-search/dist/leaflet-search.min.css';
-import { MAP_CONFIG, DRAW_CONTROL } from '../../constants/map';
+import { MAP_CONFIG } from '../../constants/map';
 
 class Map extends React.Component {
 
@@ -38,17 +34,8 @@ class Map extends React.Component {
     this.setAttribution();
     this.setZoomControl();
     this.setBasemap();
-    this.setLayers();
-    if (this.props.editable) {
-      this.setDrawing();
-      this.setDrawPolygon();
-    }
 
-    this.searchLayer = L.layerGroup().addTo(this.map);
-    this.map.addControl(new L.Control.Search({
-      layer: this.searchLayer,
-      position: 'topright'
-    }));
+    this.props.map(this.map);
   }
 
 
@@ -65,53 +52,6 @@ class Map extends React.Component {
     this.tileLayer = L.tileLayer(MAP_CONFIG.basemap, {})
                       .addTo(this.map)
                       .setZIndex(0);
-  }
-
-  setLayers() {
-    this.featureGroup = new L.FeatureGroup();
-    this.map.addLayer(this.featureGroup);
-  }
-
-  setDrawing() {
-    const drawControl = Object.assign(DRAW_CONTROL, {
-      edit: {
-        featureGroup: this.featureGroup,
-        remove: true
-      }
-    });
-    this.drawControl = new L.Control.Draw(drawControl);
-
-    this.map.addControl(this.drawControl);
-
-    // DRAW LISTENERS
-    this.map.on(L.Draw.Event.CREATED, (e) => {
-      this.onDrawEventComplete(e);
-    });
-
-    this.map.on(L.Draw.Event.DELETED, (e) => {
-      this.onDrawEventDelete(e);
-    });
-  }
-
-  setDrawPolygon() {
-    new L.Draw.Polygon(this.map, this.drawControl.options.draw.polygon).enable();
-  }
-
-
-  // MAP LISTENERS
-  onDrawEventComplete(e) {
-    const layer = e.layer;
-    this.featureGroup.addLayer(layer);
-    this.props.onDrawComplete && this.props.onDrawComplete(this.featureGroup.getLayers()[0].toGeoJSON());
-  }
-
-  onDrawEventDelete(e) {
-    const layer = e.layer;
-    this.featureGroup.removeLayer(layer);
-    this.props.onDrawComplete && this.props.onDrawComplete();
-    if (this.featureGroup.getLayers().length === 0) {
-      this.setDrawPolygon();
-    }
   }
 
 

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -26,8 +26,8 @@ class Map extends React.Component {
       zoom: this.props.mapConfig.zoom,
       center: MAP_CONFIG.center,
       detectRetina: true,
-      zoomControl: isNaN(this.props.mapConfig.zoomControl) ? MAP_CONFIG.zoomControl : this.props.mapConfig.zoomControl,
-      scrollWheelZoom: !!this.props.mapConfig.scrollWheelZoom
+      zoomControl: this.props.mapConfig.zoomControl || false,
+      scrollWheelZoom: this.props.mapConfig.scrollWheelZoom || false
     });
 
     // SETTERS

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -19,8 +19,9 @@ class Map extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // Zoom
-    this.map.setZoom(nextProps.mapConfig.zoom);
+    if (this.props.mapConfig.zoom !== nextProps.mapConfig.zoom) {
+      this.map.setZoom(nextProps.mapConfig.zoom);
+    }
   }
 
   initMap() {

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -19,7 +19,7 @@ class AreasManage extends React.Component {
     this.form = {};
     this.state = {
       mapConfig: {
-        zoom: 3,
+        zoom: 10,
         lat: 0,
         lng: 0,
         zoomControl: false,
@@ -36,11 +36,11 @@ class AreasManage extends React.Component {
 
   onSubmit(e) {
     e.preventDefault();
-    if (this.form.area) {
-      toastr.success('Area saved', 'Note: in dev mode, area not saved to API');
-      this.props.saveGeostore(this.form.area);
+    if (this.form.geojson) {
+      toastr.success('Area saved', 'Note: in dev mode, geojson not saved to API');
+      this.props.saveAreaWithGeostore(this.form);
     } else {
-      toastr.error('Area needed', 'You cannot save without drawing an area');
+      toastr.error('Area needed', 'You cannot save without drawing an geojson');
     }
   }
 
@@ -52,7 +52,7 @@ class AreasManage extends React.Component {
     if (areaGeoJson) {
       const area = geojsonArea.geometry(areaGeoJson.geometry);
       if (area <= AREAS.maxSize) {
-        this.form.area = areaGeoJson;
+        this.form.geojson = areaGeoJson;
       } else {
         toastr.error('Area too large', 'Please draw a smaller area');
       }
@@ -60,8 +60,8 @@ class AreasManage extends React.Component {
   }
 
   onDrawDelete() {
-    if (this.form.area) {
-      delete this.form.area;
+    if (this.form.geojson) {
+      delete this.form.geojson;
     }
   }
 

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -101,25 +101,27 @@ class AreasManage extends React.Component {
             </div>
           </div>
           <div className="row columns">
-            <div className="c-form">
+            <div className="c-form -nav">
               <Link to="/areas">
                 <button className="c-button -light">Cancel</button>
               </Link>
-              <div className="upload-field">
-                <Icon name="icon-download" className="-medium -transparent -stroke-green" />
-                <span className="text">Upload an Area</span>
-              </div>
-              <span className="separator -vertical"></span>
-              <div className="horizontal-field">
-                <label className="text -x-small-title">Name the Area: </label>
-                <Input
-                  type="text"
-                  onChange={this.onInputChange}
-                  name="name"
-                  value=""
-                  placeholder=""
-                  validations={['required']}
-                  />
+              <div className="areas-inputs">
+                <div className="upload-field">
+                  <span className="text -x-small-title">Upload an Area</span>
+                  <Icon name="icon-download" className="-big -transparent -stroke-green" />
+                </div>
+                <span className="separator -vertical"></span>
+                <div className="horizontal-field">
+                  <label className="text -x-small-title">Name the Area: </label>
+                  <Input
+                    type="text"
+                    onChange={this.onInputChange}
+                    name="name"
+                    value=""
+                    placeholder="type your title"
+                    validations={['required']}
+                    />
+                </div>
               </div>
               <Button className="c-button">Save</Button>
             </div>

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -7,6 +7,7 @@ import { validation } from '../../../helpers/validation'; // eslint-disable-line
 import { toastr } from 'react-redux-toastr';
 import Icon from '../../ui/Icon';
 import ZoomControl from '../../ui/ZoomControl';
+import DrawControl from '../../ui/DrawControl';
 
 class AreasManage extends React.Component {
 
@@ -20,7 +21,8 @@ class AreasManage extends React.Component {
         lng: 0,
         zoomControl: false,
         scrollWheelZoom: false
-      }
+      },
+      map: {}
     }
 
     this.onSubmit = this.onSubmit.bind(this);
@@ -51,7 +53,9 @@ class AreasManage extends React.Component {
             <Map
               editable={true}
               mapConfig={this.state.mapConfig}
-              onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
+              map={(map) => {
+                this.setState({map});
+              }}
             />
             <ZoomControl
               zoom={this.state.mapConfig.zoom}
@@ -66,6 +70,10 @@ class AreasManage extends React.Component {
                 });
               }}
             />
+          <DrawControl
+            map={this.state.map}
+            onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
+          />
           </div>
           <div className="row columns">
             <div className="c-form">

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -57,23 +57,25 @@ class AreasManage extends React.Component {
                 this.setState({map});
               }}
             />
-            <ZoomControl
-              zoom={this.state.mapConfig.zoom}
-              minZoom={3}
-              maxZoom={13}
-              onZoomChange={ (zoom) => {
-                this.setState({
-                  mapConfig: {
-                    ...this.state.mapConfig,
-                    zoom
-                  }
-                });
-              }}
-            />
-          <DrawControl
-            map={this.state.map}
-            onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
-          />
+          <div className="c-map-controls">
+              <ZoomControl
+                zoom={this.state.mapConfig.zoom}
+                minZoom={3}
+                maxZoom={13}
+                onZoomChange={ (zoom) => {
+                  this.setState({
+                    mapConfig: {
+                      ...this.state.mapConfig,
+                      zoom
+                    }
+                  });
+                }}
+                />
+              <DrawControl
+                map={this.state.map}
+                onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
+                />
+            </div>
           </div>
           <div className="row columns">
             <div className="c-form">

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -15,7 +15,7 @@ class AreasManage extends React.Component {
     this.form = {};
     this.state = {
       mapConfig: {
-        zoom: 2,
+        zoom: 3,
         lat: 0,
         lng: 0,
         zoomControl: false,
@@ -47,7 +47,7 @@ class AreasManage extends React.Component {
           title="Create an Area of Interest"
         />
         <Form onSubmit={this.onSubmit}>
-          <div className="c-map-container">
+          <div className="l-map">
             <Map
               editable={true}
               mapConfig={this.state.mapConfig}
@@ -55,12 +55,14 @@ class AreasManage extends React.Component {
             />
             <ZoomControl
               zoom={this.state.mapConfig.zoom}
-              minZoom={1}
-              maxZoom={12}
+              minZoom={3}
+              maxZoom={13}
               onZoomChange={ (zoom) => {
-                this.setState((previousState) => {
-                  previousState.mapConfig.zoom = zoom;
-                  return previousState;
+                this.setState({
+                  mapConfig: {
+                    ...this.state.mapConfig,
+                    zoom
+                  }
                 });
               }}
             />

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -38,6 +38,7 @@ class AreasManage extends React.Component {
     e.preventDefault();
     if (this.form.area) {
       toastr.success('Area saved', 'Note: in dev mode, area not saved to API');
+      this.props.postArea(this.form);
     } else {
       toastr.error('Area needed', 'You cannot save without drawing an area');
     }

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -8,6 +8,9 @@ import { toastr } from 'react-redux-toastr';
 import Icon from '../../ui/Icon';
 import ZoomControl from '../../ui/ZoomControl';
 import DrawControl from '../../ui/DrawControl';
+import { AREAS } from '../../../constants/map';
+
+const geojsonArea = require('@mapbox/geojson-area');
 
 class AreasManage extends React.Component {
 
@@ -27,6 +30,8 @@ class AreasManage extends React.Component {
 
     this.onSubmit = this.onSubmit.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
+    this.onDrawComplete = this.onDrawComplete.bind(this);
+    this.onDrawDelete = this.onDrawDelete.bind(this);
   }
 
   onSubmit(e) {
@@ -40,6 +45,23 @@ class AreasManage extends React.Component {
 
   onInputChange(e) {
     this.form[e.target.name] = e.target.value;
+  }
+
+  onDrawComplete(areaGeoJson) {
+    if (areaGeoJson) {
+      const area = geojsonArea.geometry(areaGeoJson.geometry);
+      if (area <= AREAS.maxSize) {
+        this.form.area = areaGeoJson;
+      } else {
+        toastr.error('Area too large', 'Please draw a smaller area');
+      }
+    }
+  }
+
+  onDrawDelete() {
+    if (this.form.area) {
+      delete this.form.area;
+    }
   }
 
   render() {
@@ -57,7 +79,7 @@ class AreasManage extends React.Component {
                 this.setState({map});
               }}
             />
-          <div className="c-map-controls">
+            <div className="c-map-controls">
               <ZoomControl
                 zoom={this.state.mapConfig.zoom}
                 minZoom={3}
@@ -73,7 +95,8 @@ class AreasManage extends React.Component {
                 />
               <DrawControl
                 map={this.state.map}
-                onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
+                onDrawComplete={this.onDrawComplete}
+                onDrawDelete={this.onDrawDelete}
                 />
             </div>
           </div>

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -38,7 +38,7 @@ class AreasManage extends React.Component {
     e.preventDefault();
     if (this.form.area) {
       toastr.success('Area saved', 'Note: in dev mode, area not saved to API');
-      this.props.postArea(this.form);
+      this.props.saveGeostore(this.form.area);
     } else {
       toastr.error('Area needed', 'You cannot save without drawing an area');
     }

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -6,12 +6,22 @@ import { Link } from 'react-router-dom';
 import { validation } from '../../../helpers/validation'; // eslint-disable-line no-unused-vars
 import { toastr } from 'react-redux-toastr';
 import Icon from '../../ui/Icon';
+import ZoomControl from '../../ui/ZoomControl';
 
 class AreasManage extends React.Component {
 
   constructor() {
     super();
     this.form = {};
+    this.state = {
+      mapConfig: {
+        zoom: 2,
+        lat: 0,
+        lng: 0,
+        zoomControl: false,
+        scrollWheelZoom: false
+      }
+    }
 
     this.onSubmit = this.onSubmit.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
@@ -37,10 +47,24 @@ class AreasManage extends React.Component {
           title="Create an Area of Interest"
         />
         <Form onSubmit={this.onSubmit}>
-          <Map
-            editable={true}
-            onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
-          />
+          <div className="c-map-container">
+            <Map
+              editable={true}
+              mapConfig={this.state.mapConfig}
+              onDrawComplete={(areaGeoJSON) => { this.form.area = areaGeoJSON }}
+            />
+            <ZoomControl
+              zoom={this.state.mapConfig.zoom}
+              minZoom={1}
+              maxZoom={12}
+              onZoomChange={ (zoom) => {
+                this.setState((previousState) => {
+                  previousState.mapConfig.zoom = zoom;
+                  return previousState;
+                });
+              }}
+            />
+          </div>
           <div className="row columns">
             <div className="c-form">
               <Link to="/areas">

--- a/src/components/pages/areas-manage/AreasManageContainer.js
+++ b/src/components/pages/areas-manage/AreasManageContainer.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { postArea } from '../../../modules/areas';
+
+import AreasManage from './AreasManage';
+
+const mapStateToProps = ({ areas }) => ({
+  areasList: areas.ids,
+  loading: areas.loading
+});
+
+function mapDispatchToProps(dispatch) {
+  return {
+    postArea: (area) => {
+      dispatch(postArea(area));
+    }
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AreasManage);

--- a/src/components/pages/areas-manage/AreasManageContainer.js
+++ b/src/components/pages/areas-manage/AreasManageContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { saveGeostore } from '../../../modules/geostores';
+import { saveAreaWithGeostore } from '../../../modules/areas';
 
 import AreasManage from './AreasManage';
 
@@ -10,8 +10,8 @@ const mapStateToProps = ({ areas }) => ({
 
 function mapDispatchToProps(dispatch) {
   return {
-    saveGeostore: (geojson) => {
-      dispatch(saveGeostore(geojson));
+    saveAreaWithGeostore: (area) => {
+      dispatch(saveAreaWithGeostore(area));
     }
   };
 }

--- a/src/components/pages/areas-manage/AreasManageContainer.js
+++ b/src/components/pages/areas-manage/AreasManageContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { postArea } from '../../../modules/areas';
+import { saveGeostore } from '../../../modules/geostores';
 
 import AreasManage from './AreasManage';
 
@@ -10,8 +10,8 @@ const mapStateToProps = ({ areas }) => ({
 
 function mapDispatchToProps(dispatch) {
   return {
-    postArea: (area) => {
-      dispatch(postArea(area));
+    saveGeostore: (geojson) => {
+      dispatch(saveGeostore(geojson));
     }
   };
 }

--- a/src/components/pages/areas/Areas.js
+++ b/src/components/pages/areas/Areas.js
@@ -10,10 +10,6 @@ import Icon from '../../ui/Icon';
 
 class Areas extends React.Component {
 
-  componentWillMount() {
-    if (!this.props.areasList.length) this.props.getGeoStoresWithAreas();
-  }
-
   getAddArea = () => {
     if (this.props.loading) return null;
     return (
@@ -51,7 +47,6 @@ class Areas extends React.Component {
 
 Areas.propTypes = {
   areasList: PropTypes.array.isRequired,
-  getGeoStoresWithAreas: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/pages/areas/Areas.js
+++ b/src/components/pages/areas/Areas.js
@@ -11,7 +11,7 @@ import Icon from '../../ui/Icon';
 class Areas extends React.Component {
 
   componentWillMount() {
-    this.props.getGeoStoresWithAreas();
+    if (!this.props.areasList.length) this.props.getGeoStoresWithAreas();
   }
 
   getAddArea = () => {

--- a/src/components/pages/areas/Areas.js
+++ b/src/components/pages/areas/Areas.js
@@ -11,7 +11,7 @@ import Icon from '../../ui/Icon';
 class Areas extends React.Component {
 
   componentWillMount() {
-    if (!this.props.areasList.length) this.props.getUserAreas();
+    this.props.getGeoStoresWithAreas();
   }
 
   getAddArea = () => {
@@ -51,7 +51,7 @@ class Areas extends React.Component {
 
 Areas.propTypes = {
   areasList: PropTypes.array.isRequired,
-  getUserAreas: PropTypes.func.isRequired,
+  getGeoStoresWithAreas: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/pages/areas/AreasContainer.js
+++ b/src/components/pages/areas/AreasContainer.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { getGeoStoresWithAreas } from '../../../modules/areas';
 
 import Areas from './Areas';
 
@@ -8,12 +7,4 @@ const mapStateToProps = ({ areas }) => ({
   loading: areas.loading
 });
 
-function mapDispatchToProps(dispatch) {
-  return {
-    getGeoStoresWithAreas: () => {
-      dispatch(getGeoStoresWithAreas());
-    }
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Areas);
+export default connect(mapStateToProps)(Areas);

--- a/src/components/pages/areas/AreasContainer.js
+++ b/src/components/pages/areas/AreasContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getUserAreas } from '../../../modules/areas';
+import { getGeoStoresWithAreas } from '../../../modules/areas';
 
 import Areas from './Areas';
 
@@ -10,8 +10,8 @@ const mapStateToProps = ({ areas }) => ({
 
 function mapDispatchToProps(dispatch) {
   return {
-    getUserAreas: () => {
-      dispatch(getUserAreas());
+    getGeoStoresWithAreas: () => {
+      dispatch(getGeoStoresWithAreas());
     }
   };
 }

--- a/src/components/pages/dashboard/Dashboard.js
+++ b/src/components/pages/dashboard/Dashboard.js
@@ -6,7 +6,7 @@ class Dashboard extends React.Component {
 
   componentWillMount() {
     this.trimQueryParams();
-    this.props.getUserAreas();
+    this.props.getAreas();
   }
 
   trimQueryParams() {
@@ -31,7 +31,7 @@ class Dashboard extends React.Component {
 Dashboard.propTypes = {
   location: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
-  getUserAreas: PropTypes.func.isRequired
+  getAreas: PropTypes.func.isRequired
 };
 
 export default Dashboard;

--- a/src/components/pages/dashboard/DashboardContainer.js
+++ b/src/components/pages/dashboard/DashboardContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { getUserReports, getUserQuestionares } from '../../../modules/data';
-import { getUserAreas } from '../../../modules/areas';
+import { getAreas } from '../../../modules/areas';
 
 import Dashboard from './Dashboard';
 
@@ -10,8 +10,8 @@ const mapStateToProps = ({ data }) => ({
 
 function mapDispatchToProps(dispatch) {
   return {
-    getUserAreas: () => {
-      dispatch(getUserAreas());
+    getAreas: () => {
+      dispatch(getAreas());
     },
     getUserReports: () => {
       dispatch(getUserReports());

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import L from 'leaflet';
 import { Draw, Control } from 'leaflet-draw'; // eslint-disable-line no-unused-vars
 import { DRAW_CONTROL } from '../../constants/map';
@@ -47,6 +48,10 @@ class DrawControl extends React.Component {
       this.onDrawEventComplete(e);
     });
 
+    this.map.on(L.Draw.Event.EDITED, (e) => {
+      this.onDrawEventEdit(e);
+    });
+
     this.map.on(L.Draw.Event.DELETED, (e) => {
       this.onDrawEventDelete(e);
     });
@@ -60,14 +65,24 @@ class DrawControl extends React.Component {
   // EVENT LISTENERS
   onDrawEventComplete(e) {
     const layer = e.layer;
+    const geoJsonLayer = layer.toGeoJSON();
     this.featureGroup.addLayer(layer);
-    this.props.onDrawComplete && this.props.onDrawComplete(this.featureGroup.getLayers()[0].toGeoJSON());
+    this.props.onDrawComplete && this.props.onDrawComplete(geoJsonLayer);
+  }
+
+  onDrawEventEdit(e) {
+    const layers = e.layers;
+    layers.eachLayer(layer => {
+      const geoJsonLayer = layer.toGeoJSON();
+      this.featureGroup.addLayer(layer);
+      this.props.onDrawComplete && this.props.onDrawComplete(geoJsonLayer);
+    });
   }
 
   onDrawEventDelete(e) {
     const layer = e.layer;
     this.featureGroup.removeLayer(layer);
-    this.props.onDrawComplete && this.props.onDrawComplete();
+    this.props.onDrawComplete && this.props.onDrawDelete();
     if (this.featureGroup.getLayers().length === 0) {
       this.setDrawPolygon();
     }
@@ -79,7 +94,7 @@ class DrawControl extends React.Component {
 }
 
 DrawControl.propTypes = {
-  map: React.PropTypes.object
+  map: PropTypes.object
 };
 
 export default DrawControl;

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import L from 'leaflet';
+import { Draw, Control } from 'leaflet-draw'; // eslint-disable-line no-unused-vars
+import { DRAW_CONTROL } from '../../constants/map';
+import 'leaflet-draw/dist/leaflet.draw.css';
+
+class DrawControl extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    // Bindings
+    this.setLayers = this.setLayers.bind(this);
+    this.setDrawing = this.setDrawing.bind(this);
+    this.setDrawPolygon = this.setDrawPolygon.bind(this);
+  }
+
+  /* Component lifecycle */
+  componentWillReceiveProps(nextProps) {
+    if (this.map !== nextProps.map) {
+      this.map = nextProps.map;
+      this.setLayers();
+      this.setDrawing();
+      this.setDrawPolygon();
+    }
+  }
+
+  // SETTERS
+  setLayers() {
+    this.featureGroup = new L.FeatureGroup();
+    this.map.addLayer(this.featureGroup);
+  }
+
+  setDrawing() {
+    const drawControl = Object.assign(DRAW_CONTROL, {
+      edit: {
+        featureGroup: this.featureGroup,
+        remove: true
+      }
+    });
+    this.drawControl = new L.Control.Draw(drawControl);
+
+    this.map.addControl(this.drawControl);
+
+    // DRAW LISTENERS
+    this.map.on(L.Draw.Event.CREATED, (e) => {
+      this.onDrawEventComplete(e);
+    });
+
+    this.map.on(L.Draw.Event.DELETED, (e) => {
+      this.onDrawEventDelete(e);
+    });
+  }
+
+  setDrawPolygon() {
+    new L.Draw.Polygon(this.map, this.drawControl.options.draw.polygon).enable();
+  }
+
+
+  // EVENT LISTENERS
+  onDrawEventComplete(e) {
+    const layer = e.layer;
+    this.featureGroup.addLayer(layer);
+    this.props.onDrawComplete && this.props.onDrawComplete(this.featureGroup.getLayers()[0].toGeoJSON());
+  }
+
+  onDrawEventDelete(e) {
+    const layer = e.layer;
+    this.featureGroup.removeLayer(layer);
+    this.props.onDrawComplete && this.props.onDrawComplete();
+    if (this.featureGroup.getLayers().length === 0) {
+      this.setDrawPolygon();
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+DrawControl.propTypes = {
+  map: React.PropTypes.object
+};
+
+export default DrawControl;

--- a/src/components/ui/ZoomControl.js
+++ b/src/components/ui/ZoomControl.js
@@ -65,5 +65,5 @@ ZoomControl.propTypes = {
 ZoomControl.defaultProps = {
   zoom: 3,
   maxZoom: 20,
-  minZoom: 2
+  minZoom: 3
 };

--- a/src/components/ui/ZoomControl.js
+++ b/src/components/ui/ZoomControl.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import classnames from 'classnames';
+import Icon from './Icon';
+
+export default class ZoomControl extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    // Bindings
+    this.increaseZoom = this.increaseZoom.bind(this);
+    this.decreaseZoom = this.decreaseZoom.bind(this);
+  }
+
+  /* Component lifecycle */
+  shouldComponentUpdate(newProps) {
+    return this.props.zoom !== newProps.zoom;
+  }
+
+  setZoom(zoom) {
+    this.props.onZoomChange && this.props.onZoomChange(zoom);
+  }
+
+  increaseZoom(evt) {
+    evt.preventDefault();
+    if (this.props.zoom === this.props.maxZoom) return;
+    this.setZoom(this.props.zoom + 1);
+  }
+
+  decreaseZoom() {
+    if (this.props.zoom === this.props.minZoom) return;
+    this.setZoom(this.props.zoom - 1);
+  }
+
+  render() {
+    const zoomInClass = classnames('zoom-control-btn', {
+      '-disabled': this.props.zoom === this.props.maxZoom
+    });
+
+    const zoomOutClass = classnames('zoom-control-btn', {
+      '-disabled': this.props.zoom === this.props.minZoom
+    });
+
+    return (
+      <div className="c-zoom-control">
+        <button className={zoomInClass} type="button" onClick={this.increaseZoom}>
+          <Icon name="icon-plus" />
+        </button>
+        <button className={zoomOutClass} type="button" onClick={this.decreaseZoom}>
+          <Icon name="icon-minus" />
+        </button>
+      </div>
+    );
+  }
+}
+
+ZoomControl.propTypes = {
+  zoom: React.PropTypes.number,
+  maxZoom: React.PropTypes.number,
+  minZoom: React.PropTypes.number,
+  onZoomChange: React.PropTypes.func
+};
+
+ZoomControl.defaultProps = {
+  zoom: 3,
+  maxZoom: 20,
+  minZoom: 2
+};

--- a/src/components/ui/ZoomControl.js
+++ b/src/components/ui/ZoomControl.js
@@ -27,7 +27,8 @@ export default class ZoomControl extends React.Component {
     this.setZoom(this.props.zoom + 1);
   }
 
-  decreaseZoom() {
+  decreaseZoom(evt) {
+    evt.preventDefault();
     if (this.props.zoom === this.props.minZoom) return;
     this.setZoom(this.props.zoom - 1);
   }
@@ -44,10 +45,10 @@ export default class ZoomControl extends React.Component {
     return (
       <div className="c-zoom-control">
         <button className={zoomInClass} type="button" onClick={this.increaseZoom}>
-          <Icon name="icon-plus" />
+          <Icon name="icon-more" className="-small" />
         </button>
         <button className={zoomOutClass} type="button" onClick={this.decreaseZoom}>
-          <Icon name="icon-minus" />
+          <Icon name="icon-less" className="-small" />
         </button>
       </div>
     );

--- a/src/components/ui/ZoomControl.js
+++ b/src/components/ui/ZoomControl.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Icon from './Icon';
 
@@ -56,10 +57,10 @@ export default class ZoomControl extends React.Component {
 }
 
 ZoomControl.propTypes = {
-  zoom: React.PropTypes.number,
-  maxZoom: React.PropTypes.number,
-  minZoom: React.PropTypes.number,
-  onZoomChange: React.PropTypes.func
+  zoom: PropTypes.number,
+  maxZoom: PropTypes.number,
+  minZoom: PropTypes.number,
+  onZoomChange: PropTypes.func
 };
 
 ZoomControl.defaultProps = {

--- a/src/components/ui/ZoomControl.js
+++ b/src/components/ui/ZoomControl.js
@@ -5,14 +5,6 @@ import Icon from './Icon';
 
 export default class ZoomControl extends React.Component {
 
-  constructor(props) {
-    super(props);
-
-    // Bindings
-    this.increaseZoom = this.increaseZoom.bind(this);
-    this.decreaseZoom = this.decreaseZoom.bind(this);
-  }
-
   /* Component lifecycle */
   shouldComponentUpdate(newProps) {
     return this.props.zoom !== newProps.zoom;
@@ -22,13 +14,13 @@ export default class ZoomControl extends React.Component {
     this.props.onZoomChange && this.props.onZoomChange(zoom);
   }
 
-  increaseZoom(evt) {
+  increaseZoom = (evt) => {
     evt.preventDefault();
     if (this.props.zoom === this.props.maxZoom) return;
     this.setZoom(this.props.zoom + 1);
   }
 
-  decreaseZoom(evt) {
+  decreaseZoom = (evt) => {
     evt.preventDefault();
     if (this.props.zoom === this.props.minZoom) return;
     this.setZoom(this.props.zoom - 1);

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -1,9 +1,12 @@
 // Map
-export const MAP_MIN_ZOOM = 2;
-export const MAP_INITIAL_ZOOM = 3;
-export const BASEMAP_TILE = 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
-export const MAP_CENTER = [51.505, -0.09];
-export const BASEMAP_ATTRIBUTION = 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';
+export const MAP_CONFIG = {
+  minZoom: 2,
+  initialZoom: 3,
+  basemap: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+  center: [51.505, -0.09],
+  attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+  zoomControl: false
+}
 
 // Leaflet Draw
 export const DRAW_CONTROL = {
@@ -31,4 +34,4 @@ export const DRAW_CONTROL = {
   }
 };
 
-export default { MAP_MIN_ZOOM, MAP_INITIAL_ZOOM, BASEMAP_TILE, MAP_CENTER, BASEMAP_ATTRIBUTION, DRAW_CONTROL };
+export default { MAP_CONFIG, DRAW_CONTROL };

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -21,7 +21,8 @@ export const DRAW_CONTROL = {
         },
         shapeOptions: {
           color: '#97be32'
-        }
+        },
+        showArea: true
       },
       circle: false,
       rectangle: false,
@@ -34,4 +35,8 @@ export const DRAW_CONTROL = {
   }
 };
 
-export default { MAP_CONFIG, DRAW_CONTROL };
+export const AREAS = {
+  maxSize: 1500000000 // square meters
+}
+
+export default { MAP_CONFIG, DRAW_CONTROL, AREAS };

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -22,7 +22,8 @@ export const DRAW_CONTROL = {
         shapeOptions: {
           color: '#97be32'
         },
-        showArea: true
+        showArea: true,
+        metric: true
       },
       circle: false,
       rectangle: false,

--- a/src/index.scss
+++ b/src/index.scss
@@ -34,3 +34,4 @@
 @import "./styles/components/c-card";
 @import "./styles/components/c-map";
 @import "./styles/components/c-form";
+@import "./styles/components/c-zoom-control";

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,6 +20,7 @@
 @import "./styles/layouts/l-main";
 @import "./styles/layouts/l-header";
 @import "./styles/layouts/l-content";
+@import "./styles/layouts/l-map";
 
 /* Components */
 @import "./styles/components/c-nav";

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,6 +15,7 @@
 
 /* Overides */
 @import "./styles/leaflet";
+@import "./styles/toastr";
 
 /* Layouts */
 @import "./styles/layouts/l-main";

--- a/src/index.scss
+++ b/src/index.scss
@@ -36,4 +36,3 @@
 @import "./styles/components/c-map";
 @import "./styles/components/c-form";
 @import "./styles/components/c-zoom-control";
-@import "./styles/components/c-map-controls";

--- a/src/index.scss
+++ b/src/index.scss
@@ -36,3 +36,4 @@
 @import "./styles/components/c-map";
 @import "./styles/components/c-form";
 @import "./styles/components/c-zoom-control";
+@import "./styles/components/c-map-controls";

--- a/src/modules/areas.js
+++ b/src/modules/areas.js
@@ -1,44 +1,68 @@
 import normalize from 'json-api-normalizer';
 import { API_BASE_URL } from '../constants/global';
+import { getGeostore } from './geostores';
 
 // Actions
-const GET_USER_AREAS = 'areas/GET_AREAS';
+const GET_AREA = 'areas/GET_AREA';
+const GET_AREAS = 'areas/GET_AREAS';
+const SET_AREA = 'areas/SET_AREA';
 const SET_LOADING_AREAS = 'areas/SET_LOADING_AREAS';
+const SET_SAVING_AREA = 'areas/SET_SAVING_AREA';
 const SET_LOADING_AREAS_ERROR = 'areas/SET_LOADING_AREAS_ERROR';
+const SET_SAVING_AREA_ERROR = 'areas/SET_SAVING_AREA_ERROR';
 
 // Reducer
 const initialState = {
   ids: [],
-  area: {},
+  areas: {},
   loading: false,
-  error: null
+  error: null,
+  saving: false
 };
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case GET_USER_AREAS: {
-      const { area } = action.payload;
-      if (area) return Object.assign({}, state, { ids: Object.keys(area), area });
+    case GET_AREA: {
+      const area = action.payload;
+      if (area) return {
+        ...state,
+        ids: [...state.ids, ...Object.keys(area)],
+        areas: { ...state.area, ...area }
+      };
       return state;
+    }
+    case GET_AREAS: {
+      const { area: areas } = action.payload;
+      if (areas) return Object.assign({}, state, { ids: Object.keys(areas), areas });
+      return state;
+    }
+    case SET_AREA: {
+      const area = action.payload;
+      return Object.assign({}, state, { ids: Object.keys(area), area });
     }
     case SET_LOADING_AREAS:
       return Object.assign({}, state, { loading: action.payload });
+    case SET_SAVING_AREA:
+      return Object.assign({}, state, { saving: action.payload });
     case SET_LOADING_AREAS_ERROR:
+      return Object.assign({}, state, { error: action.payload });
+    case SET_SAVING_AREA_ERROR:
       return Object.assign({}, state, { error: action.payload });
     default:
       return state;
   }
 }
 
+
 // Action Creators
-export function getUserAreas() {
-  const url = `${API_BASE_URL}/area`;
+export function getArea(id) {
+  const url = `${API_BASE_URL}/area/${id}`;
   return (dispatch, state) => {
     dispatch({
       type: SET_LOADING_AREAS,
       payload: true
     });
-    fetch(url, {
+    return fetch(url, {
       headers: {
         Authorization: `Bearer ${state().user.token}`
       }
@@ -50,13 +74,14 @@ export function getUserAreas() {
       .then((data) => {
       const normalized = normalize(data);
         dispatch({
-          type: GET_USER_AREAS,
+          type: GET_AREA,
           payload: normalized
         });
         dispatch({
           type: SET_LOADING_AREAS,
           payload: false
         });
+        return normalized;
       })
       .catch((error) => {
         dispatch({
@@ -68,5 +93,60 @@ export function getUserAreas() {
           payload: false
         });
       });
+  };
+}
+
+export function getAreas() {
+  const url = `${API_BASE_URL}/area`;
+  return (dispatch, state) => {
+    dispatch({
+      type: SET_LOADING_AREAS,
+      payload: true
+    });
+    return fetch(url, {
+      headers: {
+        Authorization: `Bearer ${state().user.token}`
+      }
+    })
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then((data) => {
+      const normalized = normalize(data);
+        dispatch({
+          type: GET_AREAS,
+          payload: normalized
+        });
+        dispatch({
+          type: SET_LOADING_AREAS,
+          payload: false
+        });
+        return normalized;
+      })
+      .catch((error) => {
+        dispatch({
+          type: SET_LOADING_AREAS_ERROR,
+          payload: error
+        });
+        dispatch({
+          type: SET_LOADING_AREAS,
+          payload: false
+        });
+      });
+  };
+}
+
+// async get Areas and their Geostores
+export function getGeoStoresWithAreas() {
+  return async (dispatch, state) => {
+    await dispatch(getAreas());
+    let promises = [];
+    const areasIds = state().areas.ids;
+    const areas = state().areas.areas;
+    areasIds.forEach((id) => {
+      promises.push(dispatch(getGeostore(areas[id].attributes.geostore)));
+    })
+    await Promise.all(promises);
   };
 }

--- a/src/modules/areas.js
+++ b/src/modules/areas.js
@@ -24,7 +24,7 @@ export default function reducer(state = initialState, action) {
       if (area) return {
         ...state,
         ids: [...state.ids, ...Object.keys(area)],
-        areas: { ...state.area, ...area }
+        areas: { ...state.areas, ...area }
       };
       return state;
     }
@@ -138,8 +138,7 @@ export function saveArea(area) {
     });
     fetch(url, {
       headers: {
-        Authorization: `Bearer ${state().user.token}`,
-        'Content-Type': 'multipart/form-data'
+        Authorization: `Bearer ${state().user.token}`
       },
       method: 'POST',
       body

--- a/src/modules/areas.js
+++ b/src/modules/areas.js
@@ -126,6 +126,7 @@ export function getAreas() {
   };
 }
 
+// POST name, geostore ID
 export function saveArea(area) {
   const url = `${API_BASE_URL}/area`;
   const body = new FormData();

--- a/src/modules/areas.js
+++ b/src/modules/areas.js
@@ -3,13 +3,10 @@ import { API_BASE_URL } from '../constants/global';
 import { getGeostore } from './geostores';
 
 // Actions
-const GET_AREA = 'areas/GET_AREA';
-const GET_AREAS = 'areas/GET_AREAS';
 const SET_AREA = 'areas/SET_AREA';
+const SET_AREAS = 'areas/SET_AREAS';
 const SET_LOADING_AREAS = 'areas/SET_LOADING_AREAS';
-const SET_SAVING_AREA = 'areas/SET_SAVING_AREA';
 const SET_LOADING_AREAS_ERROR = 'areas/SET_LOADING_AREAS_ERROR';
-const SET_SAVING_AREA_ERROR = 'areas/SET_SAVING_AREA_ERROR';
 
 // Reducer
 const initialState = {
@@ -22,7 +19,7 @@ const initialState = {
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case GET_AREA: {
+    case SET_AREA: {
       const area = action.payload;
       if (area) return {
         ...state,
@@ -31,22 +28,14 @@ export default function reducer(state = initialState, action) {
       };
       return state;
     }
-    case GET_AREAS: {
+    case SET_AREAS: {
       const { area: areas } = action.payload;
       if (areas) return Object.assign({}, state, { ids: Object.keys(areas), areas });
       return state;
     }
-    case SET_AREA: {
-      const area = action.payload;
-      return Object.assign({}, state, { ids: Object.keys(area), area });
-    }
     case SET_LOADING_AREAS:
       return Object.assign({}, state, { loading: action.payload });
-    case SET_SAVING_AREA:
-      return Object.assign({}, state, { saving: action.payload });
     case SET_LOADING_AREAS_ERROR:
-      return Object.assign({}, state, { error: action.payload });
-    case SET_SAVING_AREA_ERROR:
       return Object.assign({}, state, { error: action.payload });
     default:
       return state;
@@ -74,7 +63,7 @@ export function getArea(id) {
       .then((data) => {
       const normalized = normalize(data);
         dispatch({
-          type: GET_AREA,
+          type: SET_AREA,
           payload: normalized
         });
         dispatch({
@@ -115,7 +104,7 @@ export function getAreas() {
       .then((data) => {
       const normalized = normalize(data);
         dispatch({
-          type: GET_AREAS,
+          type: SET_AREAS,
           payload: normalized
         });
         dispatch({

--- a/src/modules/geostores.js
+++ b/src/modules/geostores.js
@@ -1,0 +1,76 @@
+import normalize from 'json-api-normalizer';
+import { API_BASE_URL } from '../constants/global';
+
+// Actions
+const GET_GEOSTORE = 'geostores/GET_GEOSTORE';
+const SET_LOADING_GEOSTORE = 'geostores/SET_LOADING_GEOSTORE';
+const SET_LOADING_GEOSTORE_ERROR = 'geostores/SET_LOADING_GEOSTORE_ERROR';
+
+// Reducer
+const initialState = {
+  ids: [],
+  geostores: {},
+  loading: false,
+  error: null
+};
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    case GET_GEOSTORE: {
+      const geostore = action.payload;
+      if (geostore) return {
+        ...state,
+        ids: [...state.ids, ...Object.keys(geostore)],
+        geostores: { ...state.geostores, ...geostore }
+      };
+      return state;
+    }
+    case SET_LOADING_GEOSTORE:
+      return Object.assign({}, state, { loading: action.payload });
+    case SET_LOADING_GEOSTORE_ERROR:
+      return Object.assign({}, state, { error: action.payload });
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+export function getGeostore(id) {
+  const url = `${API_BASE_URL}/geostore/${id}`;
+  return (dispatch, state) => {
+    dispatch({
+      type: SET_LOADING_GEOSTORE,
+      payload: true
+    });
+    fetch(url, {
+      headers: {
+        Authorization: `Bearer ${state().user.token}`
+      }
+    })
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then((data) => {
+      const normalized = normalize(data);
+        dispatch({
+          type: GET_GEOSTORE,
+          payload: normalized
+        });
+        dispatch({
+          type: SET_LOADING_GEOSTORE,
+          payload: false
+        });
+      })
+      .catch((error) => {
+        dispatch({
+          type: SET_LOADING_GEOSTORE_ERROR,
+          payload: error
+        });
+        dispatch({
+          type: SET_LOADING_GEOSTORE,
+          payload: false
+        });
+      });
+  };
+}

--- a/src/modules/geostores.js
+++ b/src/modules/geostores.js
@@ -75,6 +75,7 @@ export function getGeostore(id) {
   };
 }
 
+// POST geojson object
 export function saveGeostore(geojson) {
   const url = `${API_BASE_URL}/geostore`;
   const body = {

--- a/src/modules/geostores.js
+++ b/src/modules/geostores.js
@@ -2,7 +2,7 @@ import normalize from 'json-api-normalizer';
 import { API_BASE_URL } from '../constants/global';
 
 // Actions
-const GET_GEOSTORE = 'geostores/GET_GEOSTORE';
+const SET_GEOSTORE = 'geostores/SET_GEOSTORE';
 const SET_LOADING_GEOSTORE = 'geostores/SET_LOADING_GEOSTORE';
 const SET_LOADING_GEOSTORE_ERROR = 'geostores/SET_LOADING_GEOSTORE_ERROR';
 
@@ -16,7 +16,7 @@ const initialState = {
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case GET_GEOSTORE: {
+    case SET_GEOSTORE: {
       const geostore = action.payload;
       if (geostore) return {
         ...state,
@@ -54,7 +54,53 @@ export function getGeostore(id) {
       .then((data) => {
       const normalized = normalize(data);
         dispatch({
-          type: GET_GEOSTORE,
+          type: SET_GEOSTORE,
+          payload: normalized
+        });
+        dispatch({
+          type: SET_LOADING_GEOSTORE,
+          payload: false
+        });
+      })
+      .catch((error) => {
+        dispatch({
+          type: SET_LOADING_GEOSTORE_ERROR,
+          payload: error
+        });
+        dispatch({
+          type: SET_LOADING_GEOSTORE,
+          payload: false
+        });
+      });
+  };
+}
+
+export function saveGeostore(geojson) {
+  const url = `${API_BASE_URL}/geostore`;
+  const body = {
+    geojson: geojson
+  }
+  return (dispatch, state) => {
+    dispatch({
+      type: SET_LOADING_GEOSTORE,
+      payload: true
+    });
+    fetch(url, {
+      headers: {
+        Authorization: `Bearer ${state().user.token}`,
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw Error(response.statusText);
+      })
+      .then((data) => {
+      const normalized = normalize(data);
+        dispatch({
+          type: SET_GEOSTORE,
           payload: normalized
         });
         dispatch({

--- a/src/modules/geostores.js
+++ b/src/modules/geostores.js
@@ -17,7 +17,7 @@ const initialState = {
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case SET_GEOSTORE: {
-      const geostore = action.payload;
+      const geostore = action.payload.geoStore;
       if (geostore) return {
         ...state,
         ids: [...state.ids, ...Object.keys(geostore)],
@@ -85,7 +85,7 @@ export function saveGeostore(geojson) {
       type: SET_LOADING_GEOSTORE,
       payload: true
     });
-    fetch(url, {
+    return fetch(url, {
       headers: {
         Authorization: `Bearer ${state().user.token}`,
         'Content-Type': 'application/json'
@@ -107,6 +107,7 @@ export function saveGeostore(geojson) {
           type: SET_LOADING_GEOSTORE,
           payload: false
         });
+        return normalized.geoStore;
       })
       .catch((error) => {
         dispatch({

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -3,6 +3,7 @@ export { default as app } from './app';
 export { default as user } from './user';
 export { default as data } from './data';
 export { default as areas } from './areas';
+export { default as geostores } from './geostores';
 export { default as reports } from './reports';
 
 /* External reducers */

--- a/src/styles/_toastr.scss
+++ b/src/styles/_toastr.scss
@@ -1,0 +1,6 @@
+.redux-toastr {
+  .bottom-right {
+    bottom: 80px;
+    right: 10px;
+  }
+}

--- a/src/styles/components/_c-form.scss
+++ b/src/styles/components/_c-form.scss
@@ -1,9 +1,4 @@
 .c-form {
-  height: $footer-height;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
   input:focus,
   select:focus,
   textarea:focus,
@@ -21,6 +16,10 @@
 	  background-color: #ffffff;
 	  border: solid 1px #e6e6e6;
     padding: 0 15px;
+
+    &::placeholder {
+      color: rgba($theme-text, 0.3);
+    }
   }
 
   .horizontal-field {
@@ -30,16 +29,40 @@
     align-items: center;
   }
 
-  .upload-field {
-    height: 100%;
-  }
+  &.-nav {
+    height: $footer-height;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
-  .separator {
-    width: 1px;
-    
-    &.-vertical {
-      border-left: solid 1px rgba($pale-gray, 0.5);
+    .areas-inputs {
       height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: row;
+    }
+
+    .upload-field {
+      height: 100%;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+
+      .text {
+        margin-right: 5px;
+      }
+    }
+
+    .separator {
+      width: 1px;
+      margin: 0 30px;
+
+      &.-vertical {
+        border-left: solid 1px rgba($pale-gray, 0.2);
+        height: 100%;
+      }
     }
   }
 }

--- a/src/styles/components/_c-map-controls.scss
+++ b/src/styles/components/_c-map-controls.scss
@@ -1,0 +1,5 @@
+.c-map-controls {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}

--- a/src/styles/components/_c-map-controls.scss
+++ b/src/styles/components/_c-map-controls.scss
@@ -1,5 +1,0 @@
-.c-map-controls {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-}

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -5,10 +5,10 @@
   display: flex;
   flex-direction: column;
   z-index: 1000;
-  
+
   .zoom-control-btn {
     background-color: $theme-base;
-    padding: 5px;
+    padding: 10px 5px;
     margin-bottom: 2px;
     cursor: pointer;
   }

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -1,0 +1,5 @@
+.c-zoom-control {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -1,5 +1,7 @@
 .c-zoom-control {
-  position: relative;
+  position: absolute;
+  top: 20px;
+  right: 20px;
   display: flex;
   flex-direction: column;
   z-index: 1000;

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -2,4 +2,14 @@
   position: absolute;
   top: 20px;
   right: 20px;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+  
+  .zoom-control-btn {
+    background-color: $theme-base;
+    padding: 5px;
+    margin-bottom: 2px;
+    cursor: pointer;
+  }
 }

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -1,7 +1,5 @@
 .c-zoom-control {
-  position: absolute;
-  top: 20px;
-  right: 20px;
+  position: relative;
   display: flex;
   flex-direction: column;
   z-index: 1000;

--- a/src/styles/layouts/_l-map.scss
+++ b/src/styles/layouts/_l-map.scss
@@ -1,0 +1,3 @@
+.l-map {
+  position: relative;
+}

--- a/src/styles/layouts/_l-map.scss
+++ b/src/styles/layouts/_l-map.scss
@@ -10,6 +10,14 @@
 
     .leaflet-draw-toolbar {
       border: 0;
+
+      a {
+        background-size: 273px 35px;
+        width: 35px;
+        height: 35px;
+        line-height: 35px;
+        background-color: $theme-base;
+      }
     }
   }
 }

--- a/src/styles/layouts/_l-map.scss
+++ b/src/styles/layouts/_l-map.scss
@@ -1,3 +1,15 @@
 .l-map {
   position: relative;
+
+  .leaflet-draw {
+    position: absolute;
+    top: 100px;
+    right: 20px;
+    margin-top: 0;
+    margin-right: 0;
+
+    .leaflet-draw-toolbar {
+      border: 0;
+    }
+  }
 }


### PR DESCRIPTION
A slightly larger PR to enhance the editing of the areas, and ultimately save them to the API. This encompasses three sections:

1. Map controls: in order to prevent default events on the map draw functions, and to allow greater flexibility in passing in initial local state to the map for editing and creation, the ZoomControls, DrawControls, and mapConfig (initial state & constants) have been extracted to separate components. This also includes basic styles

2. Area restriction and validation: the areas are now restricted to the correct maximum size (150,000,000 m^2), and this has been integrated with the form validation and React Toastr notifications to provide feedback to the user.

3. Saving to the API: due to the fact that saving an area is dependant on initially saving a geostore and returning the id, the areas module has been refactored (and the geostores module created) to handle single action POST and GET which also saved the returned data to the store. You are now able to create a new area on the map, save it to the api, and return to the areas dashboard where the new area will appear. 

Other comments: the fetching of Areas and Geostores has been moved to the App component due to its dependancy in all views on entry of the application.