### PR TITLE
Feature: view area

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.2",
     "classnames": "^2.2.5",
+    "dom-to-image": "^2.5.2",
     "fecha": "^2.3.1",
     "file-saver": "^1.3.3",
     "history": "^4.6.1",

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -20,7 +20,6 @@ class App extends React.Component {
 
   componentWillMount() {
     this.props.checkLogged(this.props.location.search);
-    this.props.getGeoStoresWithAreas();
   }
 
   getRootComponent = () => {
@@ -48,6 +47,7 @@ class App extends React.Component {
               <Switch>
                 <Route exact path={`${match.url}areas`} component={Areas} />
                 <Route exact path={`${match.url}areas/create`} component={AreasManage} />
+                <Route exact path={`${match.url}areas/:areaId`} component={AreasManage} />
               </Switch>
               <Switch>
                 <Route exact path={`${match.url}reports`} component={Reports} />
@@ -70,8 +70,7 @@ App.propTypes = {
   userChecked: PropTypes.bool.isRequired,
   user: PropTypes.object.isRequired,
   checkLogged: PropTypes.func.isRequired,
-  logout: PropTypes.func.isRequired,
-  getGeoStoresWithAreas: PropTypes.func.isRequired
+  logout: PropTypes.func.isRequired
 };
 
 export default App;

--- a/src/components/app/AppContainer.js
+++ b/src/components/app/AppContainer.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom'
 import { checkLogged, logout } from '../../modules/user';
-import { getGeoStoresWithAreas } from '../../modules/areas';
 import App from './App';
 
 const mapStateToProps = ({ app, user }) => ({
@@ -16,9 +15,6 @@ function mapDispatchToProps(dispatch) {
     },
     logout: () => {
       dispatch(logout());
-    },
-    getGeoStoresWithAreas: () => {
-      dispatch(getGeoStoresWithAreas());
     }
   };
 }

--- a/src/components/area-card/AreaCard.js
+++ b/src/components/area-card/AreaCard.js
@@ -15,7 +15,7 @@ class AreaCard extends React.Component {
         </div>
         <ul className="area-actions">
           <li className="area-action">
-            <button className="c-button -light -small">Reports</button>
+            <Link className="c-button -light -small" to={'/reports'}>Reports</Link>
           </li>
           <li className="area-action -edit-area">
             <Link className="c-button -circle -transparent" to={`/areas/${area.id}`}>

--- a/src/components/area-card/AreaCard.js
+++ b/src/components/area-card/AreaCard.js
@@ -18,8 +18,8 @@ class AreaCard extends React.Component {
             <button className="c-button -light -small">Reports</button>
           </li>
           <li className="area-action -edit-area">
-            <Link className="c-button -round -white" to={`/areas/${area.id}`}>
-              <Icon className="-small -green" name="icon-edit"/>
+            <Link className="c-button -circle -transparent" to={`/areas/${area.id}`}>
+              <Icon className="-small -gray" name="icon-edit"/>
             </Link>
           </li>
         </ul>

--- a/src/components/area-card/AreaCard.js
+++ b/src/components/area-card/AreaCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../ui/Icon';
+import { Link } from 'react-router-dom';
 
 class AreaCard extends React.Component {
 
@@ -17,9 +18,9 @@ class AreaCard extends React.Component {
             <button className="c-button -light -small">Reports</button>
           </li>
           <li className="area-action -edit-area">
-            <button className="c-button -round -white">
+            <Link className="c-button -round -white" to={`/areas/${area.id}`}>
               <Icon className="-small -green" name="icon-edit"/>
-            </button>
+            </Link>
           </li>
         </ul>
       </div>

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -34,6 +34,8 @@ class Map extends React.Component {
     this.setAttribution();
     this.setZoomControl();
     this.setBasemap();
+
+    this.props.map(this.map);
   }
 
 

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -20,7 +20,7 @@ class Map extends React.Component {
     }
   }
 
-  initMap() {
+  initMap = () => {
     this.map = L.map('map', {
       minZoom: MAP_CONFIG.minZoom,
       zoom: this.props.mapConfig.zoom,
@@ -34,8 +34,6 @@ class Map extends React.Component {
     this.setAttribution();
     this.setZoomControl();
     this.setBasemap();
-
-    this.props.map(this.map);
   }
 
 

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -17,7 +17,7 @@ class AreasManage extends React.Component {
   constructor(props) {
     super(props);
     this.form = {
-      name: props.area.attributes.name,
+      name: props.area ? props.area.attributes.name : '',
       geojson: props.geojson || null
     };
     this.state = {
@@ -27,8 +27,7 @@ class AreasManage extends React.Component {
         lng: 0,
         zoomControl: false,
         scrollWheelZoom: false
-      },
-      map: {}
+      }
     }
 
     this.onSubmit = this.onSubmit.bind(this);
@@ -41,7 +40,7 @@ class AreasManage extends React.Component {
     e.preventDefault();
     if (this.form.geojson) {
       toastr.success('Area saved', 'Note: in dev mode, geojson not saved to API');
-      this.props.saveAreaWithGeostore(this.form);
+      this.props.saveAreaWithGeostore(this.form, this.map._container);
     } else {
       toastr.error('Area needed', 'You cannot save without drawing an geojson');
     }
@@ -79,9 +78,7 @@ class AreasManage extends React.Component {
             <Map
               editable={true}
               mapConfig={this.state.mapConfig}
-              map={(map) => {
-                this.setState({map});
-              }}
+              ref={(component) => {this.map = component && component.map;}}
             />
             <div className="c-map-controls">
               <ZoomControl
@@ -98,7 +95,7 @@ class AreasManage extends React.Component {
                 }}
                 />
               <DrawControl
-                map={this.state.map}
+                map={this.map}
                 onDrawComplete={this.onDrawComplete}
                 onDrawDelete={this.onDrawDelete}
                 geojson={this.form.geojson}

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -14,9 +14,12 @@ const geojsonArea = require('@mapbox/geojson-area');
 
 class AreasManage extends React.Component {
 
-  constructor() {
-    super();
-    this.form = {};
+  constructor(props) {
+    super(props);
+    this.form = {
+      name: props.area.attributes.name,
+      geojson: props.geojson || null
+    };
     this.state = {
       mapConfig: {
         zoom: 10,
@@ -61,7 +64,7 @@ class AreasManage extends React.Component {
 
   onDrawDelete() {
     if (this.form.geojson) {
-      delete this.form.geojson;
+      this.form.geojson = null;
     }
   }
 
@@ -98,6 +101,7 @@ class AreasManage extends React.Component {
                 map={this.state.map}
                 onDrawComplete={this.onDrawComplete}
                 onDrawDelete={this.onDrawDelete}
+                geojson={this.form.geojson}
                 />
             </div>
           </div>
@@ -118,7 +122,7 @@ class AreasManage extends React.Component {
                     type="text"
                     onChange={this.onInputChange}
                     name="name"
-                    value=""
+                    value={this.form.name}
                     placeholder="type your title"
                     validations={['required']}
                     />

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -37,6 +37,11 @@ class AreasManage extends React.Component {
     this.onDrawDelete = this.onDrawDelete.bind(this);
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.form.name = nextProps.area ? nextProps.area.attributes.name : '';
+    this.form.geojson = nextProps.geojson;
+  }
+
   onSubmit(e) {
     e.preventDefault();
     if (this.form.geojson) {

--- a/src/components/pages/areas-manage/AreasManage.js
+++ b/src/components/pages/areas-manage/AreasManage.js
@@ -21,6 +21,7 @@ class AreasManage extends React.Component {
       geojson: props.geojson || null
     };
     this.state = {
+      map: {},
       mapConfig: {
         zoom: 10,
         lat: 0,
@@ -40,7 +41,7 @@ class AreasManage extends React.Component {
     e.preventDefault();
     if (this.form.geojson) {
       toastr.success('Area saved', 'Note: in dev mode, geojson not saved to API');
-      this.props.saveAreaWithGeostore(this.form, this.map._container);
+      this.props.saveAreaWithGeostore(this.form, this.state.map._container);
     } else {
       toastr.error('Area needed', 'You cannot save without drawing an geojson');
     }
@@ -78,7 +79,9 @@ class AreasManage extends React.Component {
             <Map
               editable={true}
               mapConfig={this.state.mapConfig}
-              ref={(component) => {this.map = component && component.map;}}
+              map={(map) => {
+                this.setState({map});
+              }}
             />
             <div className="c-map-controls">
               <ZoomControl
@@ -93,13 +96,14 @@ class AreasManage extends React.Component {
                     }
                   });
                 }}
-                />
-              <DrawControl
-                map={this.map}
+              />
+            <DrawControl
+                map={this.state.map}
                 onDrawComplete={this.onDrawComplete}
                 onDrawDelete={this.onDrawDelete}
                 geojson={this.form.geojson}
                 />
+
             </div>
           </div>
           <div className="row columns">

--- a/src/components/pages/areas-manage/AreasManageContainer.js
+++ b/src/components/pages/areas-manage/AreasManageContainer.js
@@ -3,9 +3,25 @@ import { saveAreaWithGeostore } from '../../../modules/areas';
 
 import AreasManage from './AreasManage';
 
-const mapStateToProps = ({ areas }) => ({
-  areasList: areas.ids,
-  loading: areas.loading
+const readGeojson = (state, match) => {
+  const areaId = match.params.areaId;
+  const area = state.areas.areas[areaId] || null;
+  const geostoreId = area ? area.attributes.geostore : null;
+  const geostore = state.geostores.geostores[geostoreId] || null;
+  const geojson = geostore ? geostore.attributes.geojson : null;
+  return geojson;
+}
+
+const readArea = (state, match) => {
+  const areaId = match.params.areaId;
+  const area = state.areas.areas[areaId] || null;
+  return area;
+}
+
+const mapStateToProps = (state, { match }) => ({
+  loading: state.areas.loading,
+  geojson: readGeojson(state, match),
+  area: readArea(state, match)
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/components/pages/areas-manage/AreasManageContainer.js
+++ b/src/components/pages/areas-manage/AreasManageContainer.js
@@ -26,8 +26,8 @@ const mapStateToProps = (state, { match }) => ({
 
 function mapDispatchToProps(dispatch) {
   return {
-    saveAreaWithGeostore: (area) => {
-      dispatch(saveAreaWithGeostore(area));
+    saveAreaWithGeostore: (area, node) => {
+      dispatch(saveAreaWithGeostore(area, node));
     }
   };
 }

--- a/src/components/pages/areas/Areas.js
+++ b/src/components/pages/areas/Areas.js
@@ -16,7 +16,7 @@ class Areas extends React.Component {
       <Link to="/areas/create">
         <button className="c-add-card">
           <Icon name="icon-plus" className="-medium -green" />
-            Add Area
+            <span className="text -x-small-title -green">Add Area</span>
         </button>
       </Link>
     );

--- a/src/components/pages/areas/Areas.js
+++ b/src/components/pages/areas/Areas.js
@@ -34,7 +34,7 @@ class Areas extends React.Component {
             <GridGallery
               collection={areasList}
               className="area-card-item"
-              columns={{ small: 12, medium: 3 }}
+              columns={{ small: 12, medium: 4, large: 3 }}
               Component={AreaCard}
               after={this.getAddArea()}
             />

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -18,13 +18,20 @@ class DrawControl extends React.Component {
     this.disableDrawing = this.disableDrawing.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.map !== prevProps.map) {
-      this.map = this.props.map;
+  /* Component lifecycle */
+  componentWillReceiveProps(nextProps) {
+    if (this.props.map !== nextProps.map) {
+      this.map = nextProps.map;
       this.setLayers();
       this.setDrawing();
+      if (this.props.geojson) {
+        this.setFeatures();
+      }
     }
-    if (this.props.geojson || (this.props.geojson !== prevProps.geojson)) {
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.geojson !== prevProps.geojson) {
       this.setFeatures();
       this.disableDrawing();
     }

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
 import { Draw, Control } from 'leaflet-draw'; // eslint-disable-line no-unused-vars
-import { DRAW_CONTROL, DRAW_CONTROL_DISABLED } from '../../constants/map';
+import { DRAW_CONTROL, DRAW_CONTROL_DISABLED, POLYGON_STYLES } from '../../constants/map';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
 class DrawControl extends React.Component {
@@ -12,37 +12,38 @@ class DrawControl extends React.Component {
 
     // Bindings
     this.setLayers = this.setLayers.bind(this);
+    this.setFeatures = this.setFeatures.bind(this);
     this.setDrawing = this.setDrawing.bind(this);
     this.enableDrawing = this.enableDrawing.bind(this);
     this.disableDrawing = this.disableDrawing.bind(this);
   }
 
-  /* Component lifecycle */
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.map !== nextProps.map) {
-      this.map = nextProps.map;
+  componentDidUpdate(prevProps) {
+    if (this.props.map !== prevProps.map) {
+      this.map = this.props.map;
       this.setLayers();
       this.setDrawing();
+    }
+    if (this.props.geojson || (this.props.geojson !== prevProps.geojson)) {
+      this.setFeatures();
+      this.disableDrawing();
     }
   }
 
   // SETTERS
   setLayers() {
     this.featureGroup = new L.FeatureGroup();
-    if (this.props.geojson) {
-      L.geoJson(this.props.geojson, {
-        onEachFeature: (feature, layer) => {
-          layer.setStyle({
-            fillColor: '#97be32',
-            stroke: '#f2f2f2'
-          });
-          this.featureGroup.addLayer(layer);
-          this.map.fitBounds(layer.getBounds());
-        }
-      });
-    }
     this.map.addLayer(this.featureGroup);
+  }
+
+  setFeatures() {
+    L.geoJson(this.props.geojson, {
+      onEachFeature: (feature, layer) => {
+        layer.setStyle(POLYGON_STYLES);
+        this.featureGroup.addLayer(layer);
+        this.map.fitBounds(layer.getBounds());
+      }
+    });
   }
 
   setDrawing() {

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -33,6 +33,10 @@ class DrawControl extends React.Component {
     if (this.props.geojson) {
       L.geoJson(this.props.geojson, {
         onEachFeature: (feature, layer) => {
+          layer.setStyle({
+            fillColor: '#97be32',
+            stroke: '#f2f2f2'
+          });
           this.featureGroup.addLayer(layer);
           this.map.fitBounds(layer.getBounds());
         }

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -14,11 +14,13 @@ class DrawControl extends React.Component {
     this.setLayers = this.setLayers.bind(this);
     this.setDrawing = this.setDrawing.bind(this);
     this.enableDrawing = this.enableDrawing.bind(this);
+    this.disableDrawing = this.disableDrawing.bind(this);
   }
 
   /* Component lifecycle */
+
   componentWillReceiveProps(nextProps) {
-    if (this.map !== nextProps.map) {
+    if (this.props.map !== nextProps.map) {
       this.map = nextProps.map;
       this.setLayers();
       this.setDrawing();

--- a/src/components/ui/DrawControl.js
+++ b/src/components/ui/DrawControl.js
@@ -93,6 +93,7 @@ class DrawControl extends React.Component {
     this.featureGroup.addLayer(layer);
     this.props.onDrawComplete && this.props.onDrawComplete(geoJsonLayer);
     this.disableDrawing();
+    this.map.fitBounds(layer.getBounds());
   }
 
   onDrawEventEdit(e) {

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -1,3 +1,5 @@
+import L from 'leaflet';
+
 // Map
 export const MAP_CONFIG = {
   minZoom: 2,
@@ -10,6 +12,7 @@ export const MAP_CONFIG = {
 
 export const POLYGON_STYLES = {
   color: '#ffffff',
+  opacity: 1,
   fillColor: '#97be32',
   fillOpacity: 0.5,
   weight: 2
@@ -28,7 +31,11 @@ export const DRAW_CONTROL = {
         },
         shapeOptions: POLYGON_STYLES,
         showArea: true,
-        metric: true
+        metric: true,
+        icon: new L.DivIcon({
+    			iconSize: new L.Point(12, 12),
+    			className: 'leaflet-div-icon leaflet-editing-icon'
+    		})
       },
       circle: false,
       rectangle: false,

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -36,8 +36,24 @@ export const DRAW_CONTROL = {
   }
 };
 
+export const DRAW_CONTROL_DISABLED = {
+  position: 'topright',
+  draw: {
+      polyline: false,
+      polygon: false,
+      circle: false,
+      rectangle: false,
+      marker: false
+  },
+  edit: {
+      featureGroup: {},
+      remove: true,
+      allowIntersection: false
+  }
+};
+
 export const AREAS = {
   maxSize: 1500000000 // square meters
 }
 
-export default { MAP_CONFIG, DRAW_CONTROL, AREAS };
+export default { MAP_CONFIG, DRAW_CONTROL, DRAW_CONTROL_DISABLED, AREAS };

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -8,6 +8,13 @@ export const MAP_CONFIG = {
   zoomControl: false
 }
 
+export const POLYGON_STYLES = {
+  color: '#ffffff',
+  fillColor: '#97be32',
+  fillOpacity: 0.5,
+  weight: 2
+};
+
 // Leaflet Draw
 export const DRAW_CONTROL = {
   position: 'topright',
@@ -19,11 +26,7 @@ export const DRAW_CONTROL = {
           color: '#f15656',
           message: '<strong>Oh snap!<strong> you can\'t draw that!'
         },
-        shapeOptions: {
-          color: '#97be32',
-          fillColor: '#97be32',
-          stroke: '#f2f2f2'
-        },
+        shapeOptions: POLYGON_STYLES,
         showArea: true,
         metric: true
       },

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -20,7 +20,9 @@ export const DRAW_CONTROL = {
           message: '<strong>Oh snap!<strong> you can\'t draw that!'
         },
         shapeOptions: {
-          color: '#97be32'
+          color: '#97be32',
+          fillColor: '#97be32',
+          stroke: '#f2f2f2'
         },
         showArea: true,
         metric: true

--- a/src/modules/areas.js
+++ b/src/modules/areas.js
@@ -1,6 +1,7 @@
 import normalize from 'json-api-normalizer';
 import { API_BASE_URL } from '../constants/global';
 import { getGeostore, saveGeostore } from './geostores';
+import domtoimage from 'dom-to-image';
 
 // Actions
 const SET_AREA = 'areas/SET_AREA';
@@ -127,12 +128,15 @@ export function getAreas() {
 }
 
 // POST name, geostore ID
-export function saveArea(area) {
-  const url = `${API_BASE_URL}/area`;
-  const body = new FormData();
-  body.append('name', area.name);
-  body.append('geostore', area.geostore);
-  return (dispatch, state) => {
+export function saveArea(area, node) {
+  return async (dispatch, state) => {
+    const url = `${API_BASE_URL}/area`;
+    const body = new FormData();
+    const blob = await domtoimage.toBlob(node);
+    body.append('name', area.name);
+    body.append('geostore', area.geostore);
+    const image = new File([blob], 'png', {type: 'image/png', name: encodeURIComponent(area.name)})
+    body.append('image', image);
     dispatch({
       type: SET_LOADING_AREAS,
       payload: true
@@ -187,11 +191,11 @@ export function getGeoStoresWithAreas() {
 }
 
 // async save geostore then area
-export function saveAreaWithGeostore(area) {
+export function saveAreaWithGeostore(area, node) {
   return async (dispatch, state) => {
     const geostore = await dispatch(saveGeostore(area.geojson));
     const geostoreId = Object.keys(geostore)[0];
     const areaWithGeostore = {...area, geostore: geostoreId};
-    await dispatch(saveArea(areaWithGeostore));
+    await dispatch(saveArea(areaWithGeostore, node));
   };
 }

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -1,6 +1,7 @@
 import querystring from 'query-string';
 import { setUserChecked } from './app';
 import { API_BASE_URL } from '../constants/global';
+import { getGeoStoresWithAreas } from './areas';
 
 // Actions
 const GET_USER = 'user/GET_USER';
@@ -56,6 +57,7 @@ export function checkLogged(tokenParam) {
           payload: { data, token, loggedIn: true }
         });
         dispatch(setUserChecked());
+        dispatch(getGeoStoresWithAreas());
       })
       .catch((error) => {
         if (user.loggedIn) {

--- a/src/styles/_leaflet.scss
+++ b/src/styles/_leaflet.scss
@@ -3,3 +3,9 @@
 .sr-only {
   display: none;
 }
+
+.leaflet-div-icon {
+  background: $theme-accent;
+  border: 2px solid $white;
+  border-radius: 50%;
+}

--- a/src/styles/_leaflet.scss
+++ b/src/styles/_leaflet.scss
@@ -3,7 +3,3 @@
 .sr-only {
   display: none;
 }
-
-.leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-polygon {
-  display: none;
-}

--- a/src/styles/components/_c-add-card.scss
+++ b/src/styles/components/_c-add-card.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   padding: 0;
   height: 155px;
-  width: 250px;
+  width: 100%;
   border-radius: 4px;
   border: dotted $theme-accent 2px;
   color: $theme-accent;
@@ -14,5 +14,9 @@
 
   &:active {
     background-color: $medium-gray;
+  }
+
+  svg {
+    margin-right: 5px;
   }
 }

--- a/src/styles/components/_c-area-card.scss
+++ b/src/styles/components/_c-area-card.scss
@@ -5,12 +5,11 @@
   margin-bottom: 50px;
 
   .area-image {
-    width: 250px;
     height: 155px;
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
-    border-radius: 4px;
+    border-radius: 2px;
     background-color: $medium-gray;
   }
 

--- a/src/styles/components/_c-button.scss
+++ b/src/styles/components/_c-button.scss
@@ -1,5 +1,6 @@
 .c-button {
-  padding: 10px 25px;
+  height: 40px;
+  padding: 0 30px;
   border: 1px solid $theme-accent;
   border-radius: 20px;
   background: $theme-accent;
@@ -9,6 +10,7 @@
   font-weight: $font-weight-bold;
   cursor: pointer;
   outline: 0;
+  text-transform: uppercase;
 
   &.-light {
     border-color: $theme-accent;
@@ -21,9 +23,8 @@
   }
 
   &.-small {
-    padding: 10px 15px;
+    padding: 0 20px;
     font-size: 12px;
-    font-weight: $font-weight-regular;
   }
 
   &.-white {
@@ -33,5 +34,22 @@
     &:active {
       background-color: darken($white, 7%);
     }
+  }
+
+  &.-transparent {
+    border-color: rgba($theme-secondary, 0.3);
+    background: $theme-base;
+    color: $gray;
+
+    &:active {
+      background-color: darken($light-green, 7%);
+    }
+  }
+
+  &.-circle {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12.5px;
   }
 }

--- a/src/styles/components/_c-button.scss
+++ b/src/styles/components/_c-button.scss
@@ -1,4 +1,6 @@
 .c-button {
+  display: flex;
+  align-items: center;
   height: 40px;
   padding: 0 30px;
   border: 1px solid $theme-accent;

--- a/src/styles/components/_c-icon.scss
+++ b/src/styles/components/_c-icon.scss
@@ -1,5 +1,5 @@
 .c-icon {
-  margin: 0 5px;
+  // margin: 0 5px;
   width: 20px;
   height: 20px;
   flex-shrink: 0;
@@ -26,6 +26,10 @@
 
   &.-green {
     fill: $theme-accent;
+  }
+
+  &.-gray {
+    fill: $dark-gray;
   }
 
   &.-white {

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -10,6 +10,7 @@
     background-color: $theme-base;
     padding: 10px 5px;
     margin-bottom: 2px;
+    border-radius: 2px;
     cursor: pointer;
   }
 }

--- a/src/styles/components/_c-zoom-control.scss
+++ b/src/styles/components/_c-zoom-control.scss
@@ -8,7 +8,7 @@
 
   .zoom-control-btn {
     background-color: $theme-base;
-    padding: 10px 5px;
+    padding: 10px 10px;
     margin-bottom: 2px;
     border-radius: 2px;
     cursor: pointer;

--- a/src/styles/layouts/_l-map.scss
+++ b/src/styles/layouts/_l-map.scss
@@ -3,7 +3,7 @@
 
   .leaflet-draw {
     position: absolute;
-    top: 100px;
+    top: 110px;
     right: 20px;
     margin-top: 0;
     margin-right: 0;
@@ -17,7 +17,29 @@
         height: 35px;
         line-height: 35px;
         background-color: $theme-base;
+        border-radius: 2px;
+      }
+
+      .leaflet-draw-draw-polygon {
+        background-position: -28px 0px;
       }
     }
+
+    .leaflet-draw-actions {
+      right: 36px;
+    }
+  }
+
+  .leaflet-right .leaflet-draw-actions li:first-child a {
+    border-radius: 2px 0 0 2px;
+  }
+
+  .leaflet-right .leaflet-draw-actions li:last-child a {
+    border-radius: 0 2px 2px;
+  }
+
+  .leaflet-touch .leaflet-draw-actions a {
+    line-height: 34px;
+    height: 34px;
   }
 }


### PR DESCRIPTION
Another feature building PR on the areas creation and management.

#### Navigation features:
- User can navigate to "view/edit" area from /areas by clicking the pencil icon. This shows the current area name and paints the polygon on the map
- Users can now click "reports" from the /areas view to navigate to the reports index (needs filters working before updating to single area reports)

#### Map functions:
- Leaflet draw polygon button, with dynamic viewing depending on draw state
- when saving to API, a snap shot of the area is now taken and saved also
- prevent default start drawing in favour of click to start drawing to allow better 

#### Performance/bugs:
- You can now enter the application from any point in areas and the data is received correctly.

#### Other features:
- updated styles to polish interaction and consistency for all areas
- Notifications for areas saving now line up with status of save