### PR TITLE
Feature/ sync default language in form with language selector

### DIFF
--- a/src/components/pages/templates-manage/TemplatesManage.js
+++ b/src/components/pages/templates-manage/TemplatesManage.js
@@ -73,7 +73,7 @@ class TemplatesManage extends React.Component {
 
   // Render
   render() {
-    const { areasOptions, localeOptions, loading, mode } = this.props;
+    const { areasOptions, localeOptions, loading, mode, locale } = this.props;
     return (
       <div>
         <Hero
@@ -106,7 +106,7 @@ class TemplatesManage extends React.Component {
                       <Select
                         name="language-select"
                         options={localeOptions}
-                        value={this.state.defaultLanguage ? getSelectorValueFromArray(this.state.defaultLanguage, localeOptions) : null}
+                        value={this.state.defaultLanguage ? getSelectorValueFromArray(this.state.defaultLanguage, localeOptions) : locale}
                         onChange={this.onLanguageChange}
                         noResultsText={this.props.intl.formatMessage({ id: 'filters.noLanguagesAvailable' })}
                         searchable={true}

--- a/src/components/pages/templates-manage/TemplatesManageContainer.js
+++ b/src/components/pages/templates-manage/TemplatesManageContainer.js
@@ -30,9 +30,17 @@ const mapStateToProps = (state, { match }) => {
     const areasOptions = mapAreasToOptions(state.areas);
     const templateId = match.params.templateId || null;
     const localeOptions = mapLocalesToOptions(LOCALES_LIST);
+    const defaultTemplate = {
+        ...TEMPLATE,
+        name: {
+            [state.app.locale]: ""       
+        },
+        languages: [state.app.locale],
+        defaultLanguage: state.app.locale
+    }
     return {
         mode: match.params.templateId ? 'manage' : 'create',
-        template: state.templates.data[templateId] ? state.templates.data[templateId].attributes : TEMPLATE,
+        template: state.templates.data[templateId] ? state.templates.data[templateId].attributes : defaultTemplate,
         loading: state.templates.loading,
         areasOptions,
         localeOptions

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ function dispatch(action) {
 }
 
 const persistConfig = {
-  whitelist: ['user']
+  whitelist: ['user', 'app']
 };
 
 function startApp() {


### PR DESCRIPTION
Small PR to allow rehydration of language and therefore on template creation, set default language to be the same as the selector.