### PR TITLE
Add locale to post and patch teams for the emails

### DIFF
--- a/src/modules/teams.js
+++ b/src/modules/teams.js
@@ -110,7 +110,7 @@ export function createTeam(team) {
         'Content-Type': 'application/json'
       },
       method: 'POST',
-      body: getBody(team)
+      body: Object.assign(getBody(team), { locale: state().app.locale })
     })
       .then((response) => {
         if (response.ok) return response.json();
@@ -160,7 +160,7 @@ export function updateTeam(team, id) {
           'Content-Type': 'application/json'
         },
         method: 'PATCH',
-        body: getBody(team)
+        body: Object.assign(getBody(team), { locale: state().app.locale })
       }
     )
       .then((response) => {


### PR DESCRIPTION
This atomic PR adds the locale to the teams create and update to allow the emails templates to be chosen depending on the users preferred language