### PR TITLE
Add the callbackUrl to the login links

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -38,13 +38,16 @@ class App extends React.Component {
     const { user, location } = this.props;
     const search = location.search || '';
     const queryParams = querystring.parse(search);
-    if (!user.loggedIn && !queryParams.token) return <Login />;
+    const callbackUrl = queryParams.callbackUrl;
+    if (!user.loggedIn && !queryParams.token) return <Login callbackUrl={callbackUrl}/>;
     return <Redirect to="/areas" />;
   }
 
   render() {
     const { match, user, userChecked, logout, locale, setLocale } = this.props;
     if (!userChecked) return null;
+    const queryParams = querystring.parse(location.search || '');
+    const callbackUrl = queryParams.callbackUrl;
     const mergedMessages = Object.assign({}, translations[DEFAULT_LANGUAGE], translations[locale]);
     return (
       <IntlProvider 
@@ -82,7 +85,14 @@ class App extends React.Component {
                 <Route exact path={`${match.url}settings`} component={Settings} />
               </div>
             }
-            {!user.loggedIn && <Redirect to="/" />}
+            {!user.loggedIn &&
+              (callbackUrl !== undefined ?
+                <Redirect to={{
+                  pathname: '/',
+                  search: location.search
+                }}/> :
+                <Redirect to={'/'}/>)
+            }
             <ReduxToastr
               position="bottom-right"
               transitionIn="fadeIn"

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -100,7 +100,7 @@ class App extends React.Component {
               </div>
             }
             {!user.loggedIn &&
-              ((!callbackUrl || !confirmToken) ?
+              ((callbackUrl || confirmToken) ?
                 <Redirect to={{
                   pathname: '/',
                   search: location.search

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -31,7 +31,10 @@ import Nav from '../layouts/Nav';
 class App extends React.Component {
 
   componentWillMount() {
+    const queryParams = querystring.parse(this.props.location.search);
+    const confirmToken = queryParams.confirmToken;
     this.props.checkLogged(this.props.location.search);
+    if (confirmToken) this.props.confirmUser(confirmToken);
   }
 
   getRootComponent = () => {

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -31,10 +31,20 @@ import Nav from '../layouts/Nav';
 class App extends React.Component {
 
   componentWillMount() {
-    const queryParams = querystring.parse(this.props.location.search);
-    const confirmToken = queryParams.confirmToken;
     this.props.checkLogged(this.props.location.search);
-    if (confirmToken) this.props.confirmUser(confirmToken);
+  }
+
+  componentDidMount() {
+    this.checkConfirmedUser(this.props);
+  }
+  componentWillReceiveProps(nextProps) {
+    this.checkConfirmedUser(nextProps);
+  }
+
+  checkConfirmedUser(props) {
+    const queryParams = querystring.parse(props.location.search);
+    const confirmToken = queryParams.confirmToken;
+    if (confirmToken && props.user.token) this.props.confirmUser(confirmToken);
   }
 
   getRootComponent = () => {
@@ -51,6 +61,7 @@ class App extends React.Component {
     if (!userChecked) return null;
     const queryParams = querystring.parse(location.search || '');
     const callbackUrl = queryParams.callbackUrl;
+    const confirmToken = queryParams.confirmToken;
     const mergedMessages = Object.assign({}, translations[DEFAULT_LANGUAGE], translations[locale]);
     return (
       <IntlProvider 
@@ -89,7 +100,7 @@ class App extends React.Component {
               </div>
             }
             {!user.loggedIn &&
-              (callbackUrl !== undefined ?
+              ((!callbackUrl || !confirmToken) ?
                 <Redirect to={{
                   pathname: '/',
                   search: location.search

--- a/src/components/app/AppContainer.js
+++ b/src/components/app/AppContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { setLocale } from '../../modules/app';
-import { checkLogged, logout } from '../../modules/user';
+import { checkLogged, confirmUser, logout } from '../../modules/user';
 import App from './App';
 
 const mapStateToProps = ({ app, user }) => ({
@@ -14,6 +14,9 @@ function mapDispatchToProps(dispatch) {
   return {
     checkLogged: (token) => {
       dispatch(checkLogged(token));
+    },
+    confirmUser: (token) => {
+      dispatch(confirmUser(token));
     },
     logout: () => {
       dispatch(logout());

--- a/src/components/pages/login/Login.js
+++ b/src/components/pages/login/Login.js
@@ -6,8 +6,8 @@ import Icon from '../../ui/Icon';
 
 import { API_BASE_URL, API_CALLBACK_URL } from '../../../constants/global';
 
-function LoginButton({ socialNetwork }) {
-  const url =`${API_BASE_URL}/auth/${socialNetwork}?token=true&callbackUrl=${API_CALLBACK_URL}`;
+function LoginButton({ socialNetwork, callbackUrl }) {
+  const url =`${API_BASE_URL}/auth/${socialNetwork}?token=true&callbackUrl=${callbackUrl || API_CALLBACK_URL}`;
   return (
     <div className={`login-button -${socialNetwork}`}>
       <a href={url}>
@@ -21,7 +21,7 @@ function LoginButton({ socialNetwork }) {
   );
 }
 
-function Login() {
+function Login({callbackUrl}) {
   return (
     <div className="c-login row">
       <div className="column small-12">
@@ -31,9 +31,9 @@ function Login() {
             <h1 className="text -logo-title"><FormattedMessage id="app.name" /></h1>
             <p className="text -logo-subtitle"><FormattedMessage id="login.welcome" /></p>
           </div>
-          <LoginButton socialNetwork="facebook" />
-          <LoginButton socialNetwork="twitter" />
-          <LoginButton socialNetwork="google" />
+          <LoginButton socialNetwork="facebook" callbackUrl={callbackUrl}/>
+          <LoginButton socialNetwork="twitter" callbackUrl={callbackUrl}/>
+          <LoginButton socialNetwork="google" callbackUrl={callbackUrl}/>
         </div>
       </div>
     </div>

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -93,8 +93,10 @@ export function confirmUser(token) {
         dispatch({
           type: CONFIRM_USER
         });
+        toastr.success('You have become a confirmed user');
       })
       .catch((error) => {
+        toastr.error('Error in confirmation');
         console.warn(error);
       });
   };

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -3,10 +3,12 @@ import { setUserChecked } from './app';
 import { API_BASE_URL } from '../constants/global';
 import { getGeoStoresWithAreas } from './areas';
 import { getTemplates } from './templates';
+import { toastr } from 'react-redux-toastr';
 
 // Actions
 const GET_USER = 'user/GET_USER';
 const CHECK_USER_LOGGED = 'user/CHECK_USER_LOGGED';
+const CONFIRM_USER = 'user/CONFIRM_USER';
 export const LOGOUT = 'user/LOGOUT';
 
 // Reducer
@@ -20,6 +22,8 @@ export default function reducer(state = initialState, action) {
   switch (action.type) {
     case CHECK_USER_LOGGED:
       return Object.assign({}, state, { ...action.payload });
+    case CONFIRM_USER:
+      return state;
     case GET_USER: {
       if (action.payload.data) {
         const user = action.payload.data.attributes;
@@ -68,6 +72,29 @@ export function checkLogged(tokenParam) {
           });
         }
         dispatch(setUserChecked());
+        console.warn(error);
+      });
+  };
+}
+
+export function confirmUser(token) {
+  const url = `${API_BASE_URL}/teams/confirm/${token}`;
+  return (dispatch, state) => {
+    fetch(url, {
+      headers: {
+        Authorization: `Bearer ${state().user.token}`
+      }
+    })
+      .then((response) => {
+        if (response.ok) return response;
+        throw Error(response.statusText);
+      })
+      .then(async (data) => {
+        dispatch({
+          type: CONFIRM_USER
+        });
+      })
+      .catch((error) => {
         console.warn(error);
       });
   };

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -3,12 +3,12 @@ import { setUserChecked } from './app';
 import { API_BASE_URL } from '../constants/global';
 import { getGeoStoresWithAreas } from './areas';
 import { getTemplates } from './templates';
+import { getTeam } from './teams';
 import { toastr } from 'react-redux-toastr';
 
 // Actions
 const GET_USER = 'user/GET_USER';
 const CHECK_USER_LOGGED = 'user/CHECK_USER_LOGGED';
-const CONFIRM_USER = 'user/CONFIRM_USER';
 export const LOGOUT = 'user/LOGOUT';
 
 // Reducer
@@ -22,8 +22,6 @@ export default function reducer(state = initialState, action) {
   switch (action.type) {
     case CHECK_USER_LOGGED:
       return Object.assign({}, state, { ...action.payload });
-    case CONFIRM_USER:
-      return state;
     case GET_USER: {
       if (action.payload.data) {
         const user = action.payload.data.attributes;
@@ -90,10 +88,8 @@ export function confirmUser(token) {
         throw Error(response.statusText);
       })
       .then(async (data) => {
-        dispatch({
-          type: CONFIRM_USER
-        });
         toastr.success('You have become a confirmed user');
+        dispatch(getTeam(state().user.data.id));
       })
       .catch((error) => {
         toastr.error('Error in confirmation');


### PR DESCRIPTION
This PR is needed for the confirmation of the user via email or link. It triggers the confirmation url with the confirmation token after the login or even if the user is logged. It conserves the params through the different renders

- [x] Redirect to callbackUrl if specified after the social media login
- [x] Add action to confirm user if we send the token and the confirmToken