### PR TITLE
Fix landing translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8481,6 +8481,11 @@
         "invariant": "2.2.2"
       }
     },
+    "react-load-script": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
+      "integrity": "sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ=="
+    },
     "react-onclickoutside": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^15.5.4",
     "react-ga": "2.2.0",
     "react-intl": "^2.3.0",
+    "react-load-script": "0.0.6",
     "react-redux": "^4.4.5",
     "react-redux-toastr": "6.2.7",
     "react-router-dom": "^4.1.1",

--- a/public/index.html
+++ b/public/index.html
@@ -173,6 +173,15 @@
     </svg>
     <!---------------------------------------------ICONS------------------------------------------ -->
 
+    <div id="headerGfw" class="hide-translation"></div>
     <div id="app"></div>
+    <script type="text/javascript">
+      window.liveSettings = {
+        picker: '#transifexTranslateElement',
+        api_key: '%REACT_APP_GFW_API_KEY%',
+        detectlang: false,
+        site: 'gfw-watcher',
+      };
+    </script>
   </body>
 </html>

--- a/src/constants/landing.js
+++ b/src/constants/landing.js
@@ -1,12 +1,6 @@
-import { GFW_API_KEY, FACEBOOK_WIDGET_API, GOOGLE_PLUS_ONE_WIDGET_API, TWITTER_WIDGET_API } from './global';
+import { FACEBOOK_WIDGET_API, GOOGLE_PLUS_ONE_WIDGET_API, TWITTER_WIDGET_API } from './global';
 
 export const GFW_ASSETS_PATH = process.env.REACT_APP_GFW_ASSETS_PATH;
-
-export const LIVE_SETTINGS = `window.liveSettings = {
-    picker: '#transifexTranslateElement',
-    api_key: '${GFW_API_KEY}',
-    detectlang: false,
-    site: 'gfw-watcher'};`;
 
 export const SOCIAL_FOOTER_SCRIPT = `
       // Twitter
@@ -30,7 +24,6 @@ export const SOCIAL_FOOTER_SCRIPT = `
     `;
 
 export default {
-  LIVE_SETTINGS,
   SOCIAL_FOOTER_SCRIPT,
   GFW_ASSETS_PATH
 };

--- a/src/pages/landing/Landing.js
+++ b/src/pages/landing/Landing.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { LIVE_SETTINGS, GFW_ASSETS_PATH } from '../../constants/landing';
+import { GFW_ASSETS_PATH } from '../../constants/landing';
 import SocialFooter from './SocialFooter';
 import Select from 'react-select';
+import Script from 'react-load-script'
 
 class Landing extends React.Component {
 
@@ -20,30 +21,31 @@ class Landing extends React.Component {
     this.languages = props.translations && Object.keys(props.translations).map((lang) => (
       { value: lang, label: lang.toUpperCase() }
     ));
+    this.state = {
+      gfwBarLoaded: false
+    };
   }
 
-  componentDidMount() {
-    this.script = document.createElement('script');
-    this.script.type = 'text/javascript';
-    this.script.async = true;
-    this.script.innerHTML = LIVE_SETTINGS;
-
-    document.head.appendChild(this.script);
-
-    this.scriptLoader = document.createElement('script');
-    this.scriptLoader.type = 'text/javascript';
-    this.scriptLoader.async = true;
-    this.scriptLoader.id = 'loader-gfw';
-    this.scriptLoader.src = GFW_ASSETS_PATH;
-
-    document.head.appendChild(this.scriptLoader);
+  componentDidMount(){
+    this.uglyHackToSetGFWBar(true);
   }
 
   componentWillUnmount(){
-    document.head.removeChild(this.script);
-    document.head.removeChild(this.scriptLoader);
+    this.uglyHackToSetGFWBar(false);
     window._babelPolyfill = false;
   }
+
+  uglyHackToSetGFWBar(open) {
+    this.header = document.getElementById('headerGfw');
+    if (this.header) {
+      if (open) {
+        this.header.style = 'height: auto; visibility: visible;';
+      } else {
+        this.header.style = `height: 0px; visibility: hidden;`;
+      }
+    }
+  }
+
 
   handleIosLink() {
     window.location = 'https://itunes.apple.com/us/app/forest-watcher/id1277787116';
@@ -61,7 +63,7 @@ class Landing extends React.Component {
     return (
       <div className="c-landing">
         <div className="landing-nav">
-          <div className="locale-container">
+          {this.state.gfwBarLoaded && <div className="locale-container">
             <div className="locale-select-container">
               <Select
                 name="locale-select"
@@ -74,8 +76,12 @@ class Landing extends React.Component {
                 arrowRenderer={() => <svg className="c-icon -x-small -gray"><use xlinkHref="#icon-arrow-down"></use></svg>}
               />
             </div>
-          </div>
-          <div id="headerGfw"></div>
+          </div>}
+          <div id="loader-gfw" />
+          <Script
+            url={GFW_ASSETS_PATH}
+            onLoad={() => {this.setState({gfwBarLoaded: true })}}
+          />
         </div>
         <div className="row landing-content">
           <div className="column align-middle small-12 medium-12 large-6 info-column gwf-grid-adjusted">

--- a/src/styles/components/_c-landing.scss
+++ b/src/styles/components/_c-landing.scss
@@ -8,15 +8,14 @@
       position: fixed;
       z-index: 1001;
       width: 160px;
-      height: 58px;
+      height: 57px;
       right: 0;
+      top: 0;
       pointer-events: none;
-      display: none;
 
 
       @media (min-width: 850px) {
-        position: absolute;
-        width: 355px;
+        right: 150px;
       }
 
       @media (min-width: 1171px) {


### PR DESCRIPTION
Crazy and ugly at the same time transifex hack:
After making it work just (we need to add the header div outside react, I guess because the dom changed completely) I realized that it stopped working if you go back to the landing page so... we need to use the built-in selector to swap between languages... 

Using the `hide-translation` class in the gfw-header it looks very similar and works like a charm:
![image](https://user-images.githubusercontent.com/10500650/33953989-3bd67964-e037-11e7-87f8-8c86d4197072.png)
